### PR TITLE
Add into_inner() to BufStream & StreamSlice

### DIFF
--- a/src/buf_stream.rs
+++ b/src/buf_stream.rs
@@ -29,6 +29,13 @@ impl<T: Read+Write+Seek> BufStream<T> {
         }
     }
 
+    /// Returns inner object
+    pub fn into_inner(mut self) -> io::Result<T> {
+        self.flush()?;
+        let md = std::mem::ManuallyDrop::new(self);
+        Ok(unsafe { core::ptr::read(&md.inner) })
+    }
+
     fn flush_buf(&mut self) -> io::Result<()> {
         if self.write {
             self.inner.write_all(&self.buf[..self.pos])?;

--- a/src/buf_stream.rs
+++ b/src/buf_stream.rs
@@ -9,7 +9,7 @@ const BUF_SIZE: usize = 512;
 /// It is basically composition of `BufReader` and `BufWritter`.
 /// Buffer size is fixed to 512 to avoid dynamic allocation.
 /// `BufStream` automatically flushes itself when being dropped.
-pub struct BufStream<T: Read+Write+Seek>  {
+pub struct BufStream<T: Read + Write + Seek> {
     inner: T,
     buf: [u8; BUF_SIZE],
     len: usize,
@@ -17,7 +17,7 @@ pub struct BufStream<T: Read+Write+Seek>  {
     write: bool,
 }
 
-impl<T: Read+Write+Seek> BufStream<T> {
+impl<T: Read + Write + Seek> BufStream<T> {
     /// Creates a new `BufStream` object for a given inner stream.
     pub fn new(inner: T) -> Self {
         BufStream {
@@ -56,7 +56,8 @@ impl<T: Read+Write+Seek> BufStream<T> {
 
     fn make_writter(&mut self) -> io::Result<()> {
         if !self.write {
-            self.inner.seek(io::SeekFrom::Current(-(self.len as i64 - self.pos as i64)))?;
+            self.inner
+                .seek(io::SeekFrom::Current(-(self.len as i64 - self.pos as i64)))?;
             self.write = true;
             self.len = 0;
             self.pos = 0;
@@ -80,7 +81,7 @@ impl<T: Read+Write+Seek> BufStream<T> {
 }
 
 #[cfg(any(feature = "std", feature = "core_io/collections"))]
-impl<T: Read+Write+Seek> BufRead for BufStream<T> {
+impl<T: Read + Write + Seek> BufRead for BufStream<T> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         BufStream::fill_buf(self)
     }
@@ -90,7 +91,7 @@ impl<T: Read+Write+Seek> BufRead for BufStream<T> {
     }
 }
 
-impl<T: Read+Write+Seek> Read for BufStream<T> {
+impl<T: Read + Write + Seek> Read for BufStream<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // Make sure we are in read mode
         self.make_reader()?;
@@ -107,7 +108,7 @@ impl<T: Read+Write+Seek> Read for BufStream<T> {
     }
 }
 
-impl<T: Read+Write+Seek> Write for BufStream<T> {
+impl<T: Read + Write + Seek> Write for BufStream<T> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         // Make sure we are in write mode
         self.make_writter()?;
@@ -128,11 +129,13 @@ impl<T: Read+Write+Seek> Write for BufStream<T> {
     }
 }
 
-impl<T: Read+Write+Seek> Seek for BufStream<T> {
+impl<T: Read + Write + Seek> Seek for BufStream<T> {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         self.flush_buf()?;
         let new_pos = match pos {
-            io::SeekFrom::Current(x) => io::SeekFrom::Current(x - (self.len as i64 - self.pos as i64)),
+            io::SeekFrom::Current(x) => {
+                io::SeekFrom::Current(x - (self.len as i64 - self.pos as i64))
+            }
             _ => pos,
         };
         self.pos = 0;
@@ -141,7 +144,7 @@ impl<T: Read+Write+Seek> Seek for BufStream<T> {
     }
 }
 
-impl<T: Read+Write+Seek> Drop for BufStream<T> {
+impl<T: Read + Write + Seek> Drop for BufStream<T> {
     fn drop(&mut self) {
         if let Err(err) = self.flush() {
             error!("flush failed {}", err);

--- a/src/stream_slice.rs
+++ b/src/stream_slice.rs
@@ -26,6 +26,11 @@ impl <T: Read + Write + Seek> StreamSlice<T> {
             current_offset: 0,
         })
     }
+
+    /// Returns inner object
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
 }
 
 impl <T: Read + Write + Seek> Read for StreamSlice<T> {

--- a/src/stream_slice.rs
+++ b/src/stream_slice.rs
@@ -11,9 +11,9 @@ pub struct StreamSlice<T: Read + Write + Seek> {
     size: u64,
 }
 
-impl <T: Read + Write + Seek> StreamSlice<T> {
+impl<T: Read + Write + Seek> StreamSlice<T> {
     /// Creates new `StreamSlice` from inner stream and offset range.
-    /// 
+    ///
     /// `start_offset` is inclusive offset of the first accessible byte.
     /// `end_offset` is exclusive offset of the first non-accessible byte.
     /// `start_offset` must be lower or equal to `end_offset`.
@@ -22,7 +22,9 @@ impl <T: Read + Write + Seek> StreamSlice<T> {
         inner.seek(io::SeekFrom::Start(start_offset))?;
         let size = end_offset - start_offset;
         Ok(StreamSlice {
-            start_offset, size, inner,
+            start_offset,
+            size,
+            inner,
             current_offset: 0,
         })
     }
@@ -33,7 +35,7 @@ impl <T: Read + Write + Seek> StreamSlice<T> {
     }
 }
 
-impl <T: Read + Write + Seek> Read for StreamSlice<T> {
+impl<T: Read + Write + Seek> Read for StreamSlice<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let max_read_size = cmp::min((self.size - self.current_offset) as usize, buf.len());
         let bytes_read = self.inner.read(&mut buf[..max_read_size])?;
@@ -42,7 +44,7 @@ impl <T: Read + Write + Seek> Read for StreamSlice<T> {
     }
 }
 
-impl <T: Read + Write + Seek> Write for StreamSlice<T> {
+impl<T: Read + Write + Seek> Write for StreamSlice<T> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let max_write_size = cmp::min((self.size - self.current_offset) as usize, buf.len());
         let bytes_written = self.inner.write(&buf[..max_write_size])?;
@@ -55,7 +57,7 @@ impl <T: Read + Write + Seek> Write for StreamSlice<T> {
     }
 }
 
-impl <T: Read + Write + Seek> Seek for StreamSlice<T> {
+impl<T: Read + Write + Seek> Seek for StreamSlice<T> {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         let new_offset = match pos {
             io::SeekFrom::Current(x) => self.current_offset as i64 + x,
@@ -65,7 +67,8 @@ impl <T: Read + Write + Seek> Seek for StreamSlice<T> {
         if new_offset < 0 || new_offset as u64 > self.size {
             Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))
         } else {
-            self.inner.seek(io::SeekFrom::Start(self.start_offset + new_offset as u64))?;
+            self.inner
+                .seek(io::SeekFrom::Start(self.start_offset + new_offset as u64))?;
             self.current_offset = new_offset as u64;
             Ok(self.current_offset)
         }
@@ -79,7 +82,7 @@ mod tests {
     fn it_works() {
         let buf = "BeforeTest dataAfter".to_string().into_bytes();
         let cur = io::Cursor::new(buf);
-        let mut stream = StreamSlice::new(cur, 6, 6+9).unwrap();
+        let mut stream = StreamSlice::new(cur, 6, 6 + 9).unwrap();
 
         let mut data = String::new();
         stream.read_to_string(&mut data).unwrap();


### PR DESCRIPTION
The implementation of `into_inner()` for `StreamSlice` is straightforward but for `BufStream` I wrapped the inner object in an `Option` since we can't move `T` out of `BufStream<T>` because it implements the `Drop` trait.
Another way of doing this would have been to use `ManuallyDrop` (https://doc.rust-lang.org/std/mem/struct.ManuallyDrop.html) but it's unsafe so I did like `BufWriter` of the standard lib (https://doc.rust-lang.org/src/std/io/buffered/bufwriter.rs.html#67-74) and wrapped the inner object in an `Option`.